### PR TITLE
setuptools no longer needed at runtime

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - click-plugins >=1.1.1
     - click-repl >=0.2.0
     - kombu >=5.2.3,<6.0
+    - importlib-metadata >=1.4.0
     - python >=3.7
     - pytz >=2021.3
     - vine >=5.0.0,<6.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d1398cadf30f576266b34370e28e880306ec55f7a4b6307549b0ae9c15663481
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - celery = celery.__main__:main
@@ -31,7 +31,6 @@ requirements:
     - kombu >=5.2.3,<6.0
     - python >=3.7
     - pytz >=2021.3
-    - setuptools >=59.1.1,<59.7.0
     - vine >=5.0.0,<6.0
 
 test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes https://github.com/conda-forge/celery-feedstock/issues/68
<!--
Please add any other relevant info below:
-->
