### PR TITLE
build celery 5.3.0.a1 pre-release/dev label

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,5 @@
+channel_targets:
+  - conda-forge celery_dev
+
+channel_sources:
+  - conda-forge/label/kombu_dev,conda-forge

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "celery" %}
-{% set version = "5.2.7" %}
+{% set version = "5.3.0a1" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/celery-{{ version }}.tar.gz
-  sha256: fafbd82934d30f8a004f81e8f7a062e31413a23d444be8ee3326553915958c6d
+  sha256: 474056b21b4491ef3328c6e69d1911dda3e3f67967c8760b0b55b80cf8963d3b
 
 build:
   number: 0
@@ -23,12 +23,12 @@ requirements:
     - pytest
     - python >=3.7
   run:
-    - billiard >=3.6.4.0,<4.0
-    - click >=8.0.3,<9.0
-    - click-didyoumean >=0.0.3
+    - billiard >=3.6.4.0,<5.0
+    - click >=8.1.2,<9.0
+    - click-didyoumean >=0.3.0
     - click-plugins >=1.1.1
     - click-repl >=0.2.0
-    - kombu >=5.2.3,<6.0
+    - kombu >=5.3.0a1,<6.0
     - importlib-metadata >=1.4.0
     - python >=3.7
     - pytz >=2021.3
@@ -38,10 +38,10 @@ test:
   requires:
     - dnspython
     - pymongo
-    - pytest~=6.2
+    - pytest~=7.1.1
     - pytest-celery
     - pytest-subtests
-    - pytest-timeout~=1.4.2
+    - pytest-timeout~=2.1.0
     - boto3>=1.9.178
     - moto>=2.2.6
     - pip


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

- Adds `celery_dev` label for alpha/pre-release builds
- Depends on https://github.com/conda-forge/kombu-feedstock/pull/58

**NOTE: This requires adding a new `dev` branch and then re-targeting PR against `dev` branch. This PR should not be merged into celery-feedstock `main`**